### PR TITLE
Fix breakage due to missing Node.Thunk.Error type.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,8 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-either": "~0.1.2",
-    "purescript-globals": "~0.1.4"
+    "purescript-either": "~0.1.2"
   },
   "homepage": "https://github.com/andreypopp/purescript-node-thunk"
 }

--- a/src/Node/Thunk.purs
+++ b/src/Node/Thunk.purs
@@ -3,7 +3,6 @@ module Node.Thunk where
 import Control.Monad.Eff
 import Data.Either
 import Data.Function
-import Global
 
 --
 -- Thunk is represented as

--- a/src/Node/Thunk.purs
+++ b/src/Node/Thunk.purs
@@ -14,6 +14,8 @@ import Global
 --
 foreign import data Thunk :: * -> *
 
+foreign import data Error :: *
+
 foreign import resolve
   "function resolve(a) {                               \
   \  return function(cb) { cb(null, a); };             \


### PR DESCRIPTION
Re https://github.com/andreypopp/purescript-node-thunk/issues/2.